### PR TITLE
Fix wrong group in module dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.uphyca.stetho:stetho_realm:0.3.1'
+    compile 'com.uphyca:stetho_realm:0.3.1'
 }
 ```
 


### PR DESCRIPTION
Hi there!

Thanks for the library. Great stuff :+1: 

This PR just corrects the dependency group specified in the README.md.
Otherwise, your library cannot be found and you will get an error like this:

```
Error:Could not find com.uphyca.stetho:stetho_realm:0.3.1.
Required by:
    RealmStethoTest:app:unspecified
<a href="searchInBuildFiles">Search in build.gradle files</a>
```
