### PR TITLE
Fix issue with loading the wrong field type for links in 0.81

### DIFF
--- a/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
+++ b/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
@@ -572,7 +572,7 @@ public class Database implements ChromeDevtoolsDomain {
 
         @Override
         public long getLink(long columnIndex) {
-            return row.getLong(columnIndex);
+            return row.getLink(columnIndex);
         }
 
         @Override


### PR DESCRIPTION
In the code for loading the link field type in 0.81, the call for long was being used instead (causing a crash when trying to view a table with a link field). This changes that to use the correct call.
