### PR TITLE
Date型やRealmList<T>型のカラムの内容を表示

### DIFF
--- a/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
+++ b/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
@@ -249,12 +249,18 @@ public class Database implements ChromeDevtoolsDomain {
                             }
                         }
                         LinkView linkView = rowData.getLinkList(column);
+                        if(linkView.size() == 0) {
+                            flatList.add("[]");
+                            break;
+                        }
+
                         StringBuilder sb = new StringBuilder();
+                        final String delimiter = ",";
                         sb.append("[");
                         try {
                             for (int i = 0; i < linkView.size(); i++) {
                                 sb.append(((Row) getRowMethod.invoke(linkView, i)).getIndex());
-                                sb.append(",");
+                                sb.append(delimiter);
                             }
                         } catch (IllegalAccessException e) {
                             throw new RuntimeException(e);
@@ -262,9 +268,7 @@ public class Database implements ChromeDevtoolsDomain {
                             throw new RuntimeException(e.getTargetException());
                         }
                         final int len = sb.length();
-                        if (len > 1) {
-                            sb.delete(len - 1, len);
-                        }
+                        sb.delete(len - delimiter.length(), len);
                         sb.append("]");
                         flatList.add(sb.toString());
                         break;

--- a/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
+++ b/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
@@ -249,7 +249,7 @@ public class Database implements ChromeDevtoolsDomain {
                             }
                         }
                         LinkView linkView = rowData.getLinkList(column);
-                        if(linkView.size() == 0) {
+                        if (linkView.size() == 0) {
                             flatList.add("[]");
                             break;
                         }
@@ -259,7 +259,7 @@ public class Database implements ChromeDevtoolsDomain {
                         sb.append("[");
                         try {
                             for (int i = 0; i < linkView.size(); i++) {
-                                sb.append(((Row) getRowMethod.invoke(linkView, i)).getIndex());
+                                sb.append(RowWrapper.wrap((Row) getRowMethod.invoke(linkView, i)).getIndex());
                                 sb.append(delimiter);
                             }
                         } catch (IllegalAccessException e) {

--- a/stetho_realm/src/main/java/com/uphyca/stetho_realm/RealmInspectorModulesProvider.java
+++ b/stetho_realm/src/main/java/com/uphyca/stetho_realm/RealmInspectorModulesProvider.java
@@ -39,6 +39,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
 
     private static final long DEFAULT_LIMIT = 250L;
     private static final boolean DEFAULT_ASCENDING_ORDER = true;
+    private static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss z";
 
     private static final int ENCRYPTION_KEY_LENGTH = 64;
 
@@ -60,7 +61,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
                                                      InspectorModulesProvider provider,
                                                      boolean withMetaTables,
                                                      Pattern databaseNamePattern) {
-        return new RealmInspectorModulesProvider(context.getPackageName(), provider, context.getFilesDir(), withMetaTables, databaseNamePattern, DEFAULT_LIMIT, DEFAULT_ASCENDING_ORDER, null, null);
+        return new RealmInspectorModulesProvider(context.getPackageName(), provider, context.getFilesDir(), withMetaTables, databaseNamePattern, DEFAULT_LIMIT, DEFAULT_ASCENDING_ORDER, DEFAULT_DATE_FORMAT, null, null);
     }
 
     private final String packageName;
@@ -70,6 +71,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
     private final Pattern databaseNamePattern;
     private final long limit;
     private final boolean ascendingOrder;
+    private final String dateFormat;
     private byte[] defaultEncryptionKey;
     private Map<String, byte[]> encryptionKeys;
 
@@ -80,6 +82,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
                                           Pattern databaseNamePattern,
                                           long limit,
                                           boolean ascendingOrder,
+                                          String dateFormat,
                                           byte[] defaultEncryptionKey,
                                           Map<String, byte[]> encryptionKeys) {
         this.packageName = packageName;
@@ -93,6 +96,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
         }
         this.limit = limit;
         this.ascendingOrder = ascendingOrder;
+        this.dateFormat = dateFormat;
         this.defaultEncryptionKey = defaultEncryptionKey;
         this.encryptionKeys = encryptionKeys == null ? Collections.<String, byte[]>emptyMap() : encryptionKeys;
     }
@@ -113,6 +117,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
                 limit,
                 ascendingOrder,
                 defaultEncryptionKey,
+                dateFormat,
                 encryptionKeys));
         return modules;
     }
@@ -131,6 +136,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
         private File folder;
         private long limit = DEFAULT_LIMIT;
         private boolean ascendingOrder = DEFAULT_ASCENDING_ORDER;
+        private String dateFormat = DEFAULT_DATE_FORMAT;
         private byte[] defaultEncryptionKey;
         private Map<String, byte[]> encryptionKeys;
 
@@ -161,6 +167,11 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
 
         public ProviderBuilder withDescendingOrder() {
             this.ascendingOrder = false;
+            return this;
+        }
+
+        public ProviderBuilder withDateFormat(String dateFormat) {
+            this.dateFormat = dateFormat;
             return this;
         }
 
@@ -216,6 +227,7 @@ public class RealmInspectorModulesProvider implements InspectorModulesProvider {
                     databaseNamePattern,
                     limit,
                     ascendingOrder,
+                    dateFormat,
                     defaultEncryptionKey,
                     encryptionKeys);
         }


### PR DESCRIPTION
はじめまして！

ライブラリ大変便利に使用させていただいております。

現在RealmObjectのfieldにDate型とRealmList型を使用しているので、それらの値が表示できるように修正してみました。
よろしければご確認ください。
## やったこと
- Date型のオブジェクトの中身を見られるようにした
- Date型のオブジェクトを表示する際のFormatをBuilderで指定できるようにした
- RealmList型のオブジェクトを表示できるようにした
  - Listの中身のIndexをカンマ区切りで表示
## 動作確認環境
- realm-java: 0.80.3, 0.87.0, 0.88.1
- stetho: 1.3.1
