### PR TITLE
Fails to return database tables with Realm 2.0 when using named databases

### DIFF
--- a/.idea/dictionaries/zaki.xml
+++ b/.idea/dictionaries/zaki.xml
@@ -1,7 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="zaki">
-    <words>
-      <w>stetho</w>
-    </words>
-  </dictionary>
-</component>


### PR DESCRIPTION
PR to fix issue #37 (Fails to return database tables with Realm 2.0)
- Replaced DatabaseId's getPath with getName - as Realm throws a RealmFileError if you try to open the file path.
- Added printStackTrace to exceptions (for better debugging by users)
