### PR TITLE
updated realm 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ gradle.properties
 
 # for gradle, IDEA
 .gradle
-build/
+**/build/
 *.iml
 !.idea/runConfigurations/*
 .idea/*.xml

--- a/stetho_realm/build.gradle
+++ b/stetho_realm/build.gradle
@@ -42,8 +42,8 @@ android {
 }
 
 dependencies {
-    provided 'com.facebook.stetho:stetho:1.4.1'
-    provided 'io.realm:realm-android-library:2.0.0'
+    provided 'com.facebook.stetho:stetho:1.5.0'
+    provided 'io.realm:realm-android-library:3.7.0'
     compile fileTree(dir: 'libs', include: '*.jar')
 }
 

--- a/stetho_realm/src/main/java/com/uphyca/stetho_realm/RealmPeerManager.java
+++ b/stetho_realm/src/main/java/com/uphyca/stetho_realm/RealmPeerManager.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 
 import io.realm.RealmConfiguration;
 import io.realm.exceptions.RealmError;
+import io.realm.internal.OsRealmConfig;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
 
@@ -130,7 +131,7 @@ public class RealmPeerManager extends ChromePeerManager {
     }
 
     private SharedRealm openSharedRealm(String databaseId,
-            @Nullable SharedRealm.Durability durability) {
+            @Nullable OsRealmConfig.Durability durability) {
         final byte[] encryptionKey = getEncryptionKey(databaseId);
 
         final RealmConfiguration.Builder builder = new RealmConfiguration.Builder();
@@ -138,7 +139,7 @@ public class RealmPeerManager extends ChromePeerManager {
         builder.directory(databaseFile.getParentFile());
         builder.name(databaseFile.getName());
 
-        if (durability == SharedRealm.Durability.MEM_ONLY) {
+        if (durability == OsRealmConfig.Durability.MEM_ONLY) {
             builder.inMemory();
         }
         if (encryptionKey != null) {


### PR DESCRIPTION
As realm updated to 3.7.x, Durability enum moved from SharedRealm to OsRealmConfig. See:

https://github.com/realm/realm-java/commit/e3b2ce24354763fdaf2385163ff132921edea5d1#diff-8c5674eadea8036806fdea4c1505ba26