### PR TITLE
Update Realm to 3.7.1

### DIFF
--- a/stetho_realm/build.gradle
+++ b/stetho_realm/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.novoda.bintray-release'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 9
@@ -42,8 +42,8 @@ android {
 }
 
 dependencies {
-    provided 'com.facebook.stetho:stetho:1.4.1'
-    provided 'io.realm:realm-android-library:2.0.0'
+    provided 'com.facebook.stetho:stetho:1.5.0'
+    provided 'io.realm:realm-android-library:3.7.1'
     compile fileTree(dir: 'libs', include: '*.jar')
 }
 

--- a/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
+++ b/stetho_realm/src/main/java/com/uphyca/stetho_realm/Database.java
@@ -29,7 +29,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import io.realm.internal.LinkView;
+import io.realm.internal.OsList;
 import io.realm.internal.Row;
 import io.realm.internal.Table;
 
@@ -354,13 +354,13 @@ public class Database implements ChromeDevtoolsDomain {
         return dateTimeFormatter.format(date) + " (" + date.getTime() + ')';
     }
 
-    private String formatList(LinkView linkList) {
+    private String formatList(OsList linkList) {
         final StringBuilder sb = new StringBuilder(linkList.getTargetTable().getName());
         sb.append("{");
 
         final long size = linkList.size();
         for (long pos = 0; pos < size; pos++) {
-            sb.append(linkList.getTargetRowIndex(pos));
+            sb.append(linkList.getUncheckedRow(pos).getIndex());
             sb.append(',');
         }
         if (size != 0) {
@@ -485,7 +485,7 @@ public class Database implements ChromeDevtoolsDomain {
             return row.getLink(columnIndex);
         }
 
-        LinkView getLinkList(long columnIndex) {
+        OsList getLinkList(long columnIndex) {
             return row.getLinkList(columnIndex);
         }
     }

--- a/stetho_realm/src/main/java/com/uphyca/stetho_realm/RealmPeerManager.java
+++ b/stetho_realm/src/main/java/com/uphyca/stetho_realm/RealmPeerManager.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 
 import io.realm.RealmConfiguration;
 import io.realm.exceptions.RealmError;
+import io.realm.internal.OsRealmConfig;
 import io.realm.internal.SharedRealm;
 import io.realm.internal.Table;
 
@@ -130,7 +131,7 @@ public class RealmPeerManager extends ChromePeerManager {
     }
 
     private SharedRealm openSharedRealm(String databaseId,
-            @Nullable SharedRealm.Durability durability) {
+            @Nullable OsRealmConfig.Durability durability) {
         final byte[] encryptionKey = getEncryptionKey(databaseId);
 
         final RealmConfiguration.Builder builder = new RealmConfiguration.Builder();
@@ -138,7 +139,7 @@ public class RealmPeerManager extends ChromePeerManager {
         builder.directory(databaseFile.getParentFile());
         builder.name(databaseFile.getName());
 
-        if (durability == SharedRealm.Durability.MEM_ONLY) {
+        if (durability == OsRealmConfig.Durability.MEM_ONLY) {
             builder.inMemory();
         }
         if (encryptionKey != null) {


### PR DESCRIPTION
Hello,

unfortunately stetho-realm does not work with latest Realm 3.7.1. This PR changes `LinkView` with` OsList` and add `OsRealmConfig.Durability` (this is also covered in #57).